### PR TITLE
Experimenting with skydome settings (#5)

### DIFF
--- a/src/04_SkyDome.as
+++ b/src/04_SkyDome.as
@@ -1,0 +1,40 @@
+[Setting category="SkyDome"]
+bool Setting_SkyDome = false;
+
+[Setting category="SkyDome"
+	if="Setting_SkyDome"]
+bool Setting_SkyDomeDouble = false;
+
+string g_originalSkyDome = "";
+
+void SkyDome()
+{
+	auto map = GetApp().RootMap;
+	if (map is null) {
+		return;
+	}
+
+	CSceneMobil@ mobilSkyDome;
+	bool isStadium = map.CollectionName == "Stadium";
+	auto scene = GetApp().GameScene;
+	for (uint i = 0; i < scene.Mobils.Length; i++) {
+		auto mobil = scene.Mobils[i];
+		if (
+			(isStadium && mobil.IdName == "SkyDome") ||
+			(!isStadium && i == 1)
+		) {
+			@mobilSkyDome = mobil;
+			break;
+		}
+	}
+
+	string desiredSkyDomePath = Setting_SkyDomeDouble
+		? "GameData/Sky/Media/Solid/SkyDomeDouble.Solid.Gbx"
+		: "GameData/Sky/Media/Solid/SkyDome.Solid.Gbx";
+
+	CSystemFidFile@ fidDesiredSkyDome = Fids::GetGame(skyDomePath);
+	if (fidDesiredSkyDome.Nod !is null) {
+		fidDesiredSkyDome.Preload();
+	}
+	@mobilSkyDome.Solid = cast<CPlugSolid>(Fids::Preload(fidDesiredSkyDome));
+}

--- a/src/Main.as
+++ b/src/Main.as
@@ -30,6 +30,7 @@ void Render()
 	if (Setting_OverlayScaling) { OverlayScaling(); }
 #endif
 	LevelOfDetail();
+	SkyDome();
 
 	if (Setting_FPS && Setting_FPSWhenClosed) {
 		RenderFPS();


### PR DESCRIPTION
I'm not sure how to implement this properly, but I pushed the code for it anyway. In Tweaker, this used to have an "Apply" button. It's a little inconsistent and not very useful if you have to press this button every time. So this should, at minimum:

- Automatically update when loading into a map
- Reset to the original mesh instead (eg. Canyon mountains) of picking either a double dome or a full dome
- Have shortcuts and menu controls

The first 2 points are obviously the most important. Input welcome.