### PR TITLE
Add decals settings

### DIFF
--- a/src/04_Decals.as
+++ b/src/04_Decals.as
@@ -1,0 +1,33 @@
+#if !FOREVER
+[Setting category="Decals"
+	name="Override texture decals settings"
+	description="Disabling the override will not take effect until the map is exited."]
+bool Setting_Decals = false;
+
+[Setting category="Decals"
+	name="3D Decals"
+	description="Decals utilized for 3D grass and bushes. Will only be applied after the map is exited."
+	if="Setting_Decals"]
+bool Setting_3dDecals = true;
+
+#if MP4
+[Setting category="Decals"
+	name="2D Decals"
+	description="Decals utilized for certain texture details. Will only be applied after the map is exited."
+	if="Setting_Decals"]
+bool Setting_2dDecals = true;
+#endif
+
+void SetDecals()
+{
+#if TMNEXT
+	GetSystemConfig().Display.Decals_3D__TextureDecals_ = Setting_Decals ? Setting_3dDecals : true;
+#else
+	GetSystemConfig().Display.TextureDecals_3D = Setting_Decals ? Setting_3dDecals : true;
+#endif
+
+#if MP4
+	GetSystemConfig().Display.TextureDecals_2D = Setting_Decals ? Setting_2dDecals : true;
+#endif
+}
+#endif

--- a/src/99_Shortcuts.as
+++ b/src/99_Shortcuts.as
@@ -32,6 +32,11 @@ Shortcut Setting_ZClipShortcut;
 [Setting category="Shortcuts" name="LOD"]
 Shortcut Setting_LODShortcut;
 
+#if !FOREVER
+[Setting category="Shortcuts" name="Decals"]
+Shortcut Setting_DecalsShortcut;
+#endif
+
 [Setting category="Shortcuts" name="FPS"]
 Shortcut Setting_FPSShortcut;
 
@@ -40,5 +45,8 @@ UI::InputBlocking OnKeyPress(bool down, VirtualKey key)
 	Setting_ZClip = Setting_ZClipShortcut.GetNewValue(Setting_ZClip, down, key);
 	Setting_LOD = Setting_LODShortcut.GetNewValue(Setting_LOD, down, key);
 	Setting_FPS = Setting_FPSShortcut.GetNewValue(Setting_FPS, down, key);
+#if !FOREVER
+	Setting_Decals = Setting_DecalsShortcut.GetNewValue(Setting_Decals, down, key);
+#endif
 	return UI::InputBlocking::DoNothing;
 }

--- a/src/Main.as
+++ b/src/Main.as
@@ -29,6 +29,9 @@ void Render()
 #if TMNEXT
 	if (Setting_OverlayScaling) { OverlayScaling(); }
 #endif
+#if !FOREVER
+	SetDecals();
+#endif
 	LevelOfDetail();
 
 	if (Setting_FPS && Setting_FPSWhenClosed) {
@@ -52,6 +55,11 @@ void RenderMenu()
 		if (UI::MenuItem(Icons::Cube + " Level of detail", Setting_LODShortcut.ToString(), Setting_LOD)) {
 			Setting_LOD = !Setting_LOD;
 		}
+#if !FOREVER
+		if (UI::MenuItem(Icons::PaintBrush + " Decals", Setting_DecalsShortcut.ToString(), Setting_Decals)) {
+			Setting_Decals = !Setting_Decals;
+		}
+#endif
 		if (UI::MenuItem(Icons::LineChart + " FPS", Setting_FPSShortcut.ToString(), Setting_FPS)) {
 			Setting_FPS = !Setting_FPS;
 		}


### PR DESCRIPTION
For context:

* TM Forever doesn't seem to have decal settings (I don't have access to an OP build to test, but the documentation doesn't have any decals properties)
* 2D decals in Turbo crash the game
* 2D decals in TM2020 don't seem to be used anywhere, according to multiple users like Zai and Aijena. It's also disabled by default
* In general, decals settings don't apply until you exit a map.

Also, not sure if it would be better to use "Texture Decals" instead of simply "Decals" in most places.