### PR TITLE
Only override decals if setting is enabled

### DIFF
--- a/src/04_Decals.as
+++ b/src/04_Decals.as
@@ -21,13 +21,13 @@ bool Setting_2dDecals = true;
 void SetDecals()
 {
 #if TMNEXT
-	GetSystemConfig().Display.Decals_3D__TextureDecals_ = Setting_Decals ? Setting_3dDecals : true;
+	GetSystemConfig().Display.Decals_3D__TextureDecals_ = Setting_3dDecals;
 #else
-	GetSystemConfig().Display.TextureDecals_3D = Setting_Decals ? Setting_3dDecals : true;
+	GetSystemConfig().Display.TextureDecals_3D = Setting_3dDecals;
 #endif
 
 #if MP4
-	GetSystemConfig().Display.TextureDecals_2D = Setting_Decals ? Setting_2dDecals : true;
+	GetSystemConfig().Display.TextureDecals_2D = Setting_2dDecals;
 #endif
 }
 #endif

--- a/src/Main.as
+++ b/src/Main.as
@@ -30,7 +30,7 @@ void Render()
 	if (Setting_OverlayScaling) { OverlayScaling(); }
 #endif
 #if !FOREVER
-	SetDecals();
+	if (Setting_Decals) { SetDecals(); }
 #endif
 	LevelOfDetail();
 


### PR DESCRIPTION
Otherwise it will override the user's preferences with `true`.

Apologies for missing this in the original PR.