### PR TITLE
Add splitscreen support

### DIFF
--- a/src/01_RenderDistance.as
+++ b/src/01_RenderDistance.as
@@ -32,23 +32,37 @@ void LimitRenderDistance()
 	//NOTE: For TMF, we don't use GetCurrent here, but FindCurrent (a more expensive operation).
 	//      This is to make sure we always have an accurate up-to-date camera at this point in time.
 	//      It's possible for this to get called while the camera is already destroyed.
-	auto camera = Camera::FindCurrent();
+	array<CHmsCamera@> cameras = {Camera::FindCurrent()};
+#elif MP4
+	array<CHmsCamera@> cameras = {Camera::GetCurrent()};
 #else
-	auto camera = Camera::GetCurrent();
+	array<CHmsCamera@> cameras;
+	auto viewport = GetApp().Viewport;
+
+	// Get all cameras to make the render distance limit work with splitscreen
+	for (int i = int(viewport.Cameras.Length) - 1; i >= 0; i--) {
+		auto camera = viewport.Cameras[i];
+		if (camera.m_IsOverlay3d) {
+			continue;
+		}
+		cameras.InsertLast(camera);
+	}
 #endif
-	if (camera is null) {
+	if (cameras.Length == 0 || cameras[0] is null) {
 		return;
 	}
 
-	if (!Setting_ZClip) {
+	for (uint8 i = 0; i < cameras.Length; i++) {
+		if (!Setting_ZClip) {
 #if FOREVER
-		// TMF expects FarZ to be reset to its default
-		camera.FarZ = 50000;
+			// TMF expects FarZ to be reset to its default
+			cameras[i].FarZ = 50000;
 #endif
-		return;
-	}
+			return;
+		}
 
-	camera.FarZ = Setting_ZClipDistance;
+		cameras[i].FarZ = Setting_ZClipDistance;
+	}
 
 #if !FOREVER
 	if (Setting_ZClipAsyncRender && GetApp().Editor is null) {


### PR DESCRIPTION
Currently, when playing in the splitscreen game mode, the render distance is only applied to one of the players (https://github.com/openplanet-nl/finetuner/issues/10). This PR makes the plugin loop through all cameras instead to change their render distances. This was only tested on Trackmania 2020 with 2-player splitscreen because I don't have access to Openplanet for TMF or Maniaplanet as these also have slight changes. 4-player splitscreen is also untested due to lack of controllers.
<img width="1919" height="1079" alt="grafik" src="https://github.com/user-attachments/assets/0f113b2f-8787-4855-b711-44e529ec9b1b" />
